### PR TITLE
feat: Either

### DIFF
--- a/src/main/java/io/github/janmalch/kino/util/either/Either.java
+++ b/src/main/java/io/github/janmalch/kino/util/either/Either.java
@@ -1,0 +1,72 @@
+package io.github.janmalch.kino.util.either;
+
+import io.github.janmalch.kino.problem.Problem;
+import io.github.janmalch.kino.success.Success;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.core.Response;
+
+public final class Either<P> {
+
+  private final Success<P> success;
+  private final Problem problem;
+
+  public Either(@NotNull Problem problem) {
+    this.success = null;
+    this.problem = Objects.requireNonNull(problem);
+  }
+
+  public Either(@NotNull Success<P> success) {
+    this.success = Objects.requireNonNull(success);
+    this.problem = null;
+  }
+
+  public boolean isSuccess() {
+    return this.success != null;
+  }
+
+  public boolean isFailure() {
+    return !this.isSuccess();
+  }
+
+  public Response.StatusType getStatus() {
+    return this.isSuccess() ? this.success.getStatus() : this.problem.getStatus();
+  }
+
+  @Nullable
+  public Success<P> getSuccess() {
+    return success;
+  }
+
+  @Nullable
+  public Problem getProblem() {
+    return problem;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Either<?> either = (Either<?>) o;
+    return Objects.equals(getSuccess(), either.getSuccess())
+        && Objects.equals(getProblem(), either.getProblem());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getSuccess(), getProblem());
+  }
+
+  @Override
+  public String toString() {
+    return "Either{"
+        + "isSuccess()="
+        + isSuccess()
+        + ", success="
+        + success
+        + ", problem="
+        + problem
+        + '}';
+  }
+}

--- a/src/main/java/io/github/janmalch/kino/util/either/EitherResultBuilder.java
+++ b/src/main/java/io/github/janmalch/kino/util/either/EitherResultBuilder.java
@@ -1,0 +1,18 @@
+package io.github.janmalch.kino.util.either;
+
+import io.github.janmalch.kino.control.ResultBuilder;
+import io.github.janmalch.kino.problem.Problem;
+import io.github.janmalch.kino.success.Success;
+
+public class EitherResultBuilder<P> implements ResultBuilder<Either<P>, P> {
+
+  @Override
+  public Either<P> success(Success<P> payload) {
+    return new Either<>(payload);
+  }
+
+  @Override
+  public Either<P> failure(Problem problem) {
+    return new Either<>(problem);
+  }
+}

--- a/src/test/java/io/github/janmalch/kino/control/LogInControlTest.java
+++ b/src/test/java/io/github/janmalch/kino/control/LogInControlTest.java
@@ -3,11 +3,10 @@ package io.github.janmalch.kino.control;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import io.github.janmalch.kino.api.ResponseResultBuilder;
 import io.github.janmalch.kino.api.boundary.UserResource;
 import io.github.janmalch.kino.api.model.LoginDto;
 import io.github.janmalch.kino.api.model.SignUpDto;
-import java.util.HashMap;
+import io.github.janmalch.kino.util.either.EitherResultBuilder;
 import org.junit.jupiter.api.Test;
 
 class LogInControlTest {
@@ -20,10 +19,10 @@ class LogInControlTest {
     dto.setEmail("logIn@example.com");
     dto.setPassword("Hilfe123");
     var control = new LogInControl(dto);
-    var response = control.execute(new ResponseResultBuilder<>());
-    assertEquals(400, response.getStatus());
-    var problem = (HashMap<String, Object>) response.getEntity(); // TODO: refactor when new mapper
-    assertEquals("Username or password is wrong", problem.get("title"));
+    var response = control.execute(new EitherResultBuilder<>());
+    assertEquals(400, response.getStatus().getStatusCode());
+    var problem = response.getProblem();
+    assertEquals("Username or password is wrong", problem.getTitle());
   }
 
   private void createUser() {

--- a/src/test/java/io/github/janmalch/kino/control/movie/NewMovieControlTest.java
+++ b/src/test/java/io/github/janmalch/kino/control/movie/NewMovieControlTest.java
@@ -1,12 +1,10 @@
 package io.github.janmalch.kino.control.movie;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
-import io.github.janmalch.kino.api.ResponseResultBuilder;
 import io.github.janmalch.kino.api.model.MovieDto;
+import io.github.janmalch.kino.util.either.EitherResultBuilder;
 import java.text.ParseException;
-import java.util.HashMap;
 import org.junit.jupiter.api.Test;
 
 class NewMovieControlTest {
@@ -22,10 +20,11 @@ class NewMovieControlTest {
     dto.setPriceCategory("1");
 
     var control = new NewMovieControl(dto);
-    var response = control.execute(new ResponseResultBuilder<>());
-    assertEquals(400, response.getStatus());
-    var problem = (HashMap<String, Object>) response.getEntity(); // TODO: refactor when new mapper
-    assertEquals("Start date is after the end date", problem.get("title"));
+    var response = control.execute(new EitherResultBuilder<>());
+    assertTrue(response.isFailure());
+    assertEquals(400, response.getStatus().getStatusCode());
+    var problem = response.getProblem();
+    assertEquals("Start date is after the end date", problem.getTitle());
   }
 
   @Test

--- a/src/test/java/io/github/janmalch/kino/util/either/EitherResultBuilderTest.java
+++ b/src/test/java/io/github/janmalch/kino/util/either/EitherResultBuilderTest.java
@@ -1,0 +1,37 @@
+package io.github.janmalch.kino.util.either;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.github.janmalch.kino.problem.Problem;
+import javax.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+class EitherResultBuilderTest {
+
+  @Test
+  void success() {
+    var builder = new EitherResultBuilder<Long>();
+    var either = builder.success(1L);
+    assertTrue(either.isSuccess());
+    assertNotNull(either.getSuccess());
+    assertEquals(1L, either.getSuccess().getData());
+    assertEquals(200, either.getStatus().getStatusCode());
+
+    assertFalse(either.isFailure());
+    assertNull(either.getProblem());
+  }
+
+  @Test
+  void failure() {
+    var builder = new EitherResultBuilder<Long>();
+    var either = builder.failure(Problem.valueOf(Response.Status.INTERNAL_SERVER_ERROR));
+    assertTrue(either.isFailure());
+    assertNotNull(either.getProblem());
+    assertEquals(
+        Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase(), either.getProblem().getTitle());
+    assertEquals(500, either.getStatus().getStatusCode());
+
+    assertFalse(either.isSuccess());
+    assertNull(either.getSuccess());
+  }
+}

--- a/src/test/java/io/github/janmalch/kino/util/either/EitherTest.java
+++ b/src/test/java/io/github/janmalch/kino/util/either/EitherTest.java
@@ -1,0 +1,47 @@
+package io.github.janmalch.kino.util.either;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.github.janmalch.kino.success.Success;
+import org.junit.jupiter.api.Test;
+
+class EitherTest {
+
+  @Test
+  void equals1() {
+    var success = Success.valueOf(1);
+    var either1 = new Either<>(success);
+    var either2 = new Either<>(success);
+    assertEquals(either1, either2);
+  }
+
+  @Test
+  void equals2() {
+    var success = Success.valueOf(1);
+    var either1 = new Either<>(success);
+    var either2 = either1;
+    assertEquals(either1, either2);
+  }
+
+  @Test
+  void equals3() {
+    var success = Success.valueOf(1);
+    var either1 = new Either<>(success);
+    assertNotEquals(either1, success);
+    assertNotEquals(either1, null);
+  }
+
+  @Test
+  void hashCode1() {
+    var success = Success.valueOf(1);
+    var either1 = new Either<>(success);
+    var either2 = new Either<>(success);
+    assertEquals(either1.hashCode(), either2.hashCode());
+  }
+
+  @Test
+  void toString1() {
+    var either = new Either<>(Success.valueOf(1));
+    assertTrue(either.toString().contains("isSuccess"));
+  }
+}


### PR DESCRIPTION
Added alternative `ResultBuilder`: `EitherResultBuilder`.
Keeps typing as opposed to the `ResponseResultBuilder` whose `getEntity` is always an `Object`.

#### Example

```java
// no casting needed anywhere
Control<Long> control = new ControlThatReturnsLongAsPayload();
Either<Long> result = control.execute(new EitherResultBuilder<>());
if (result.isFailure()) {
  var problem = result.getProblem();
  // ...
} else {
  var myLong = result.getSuccess().getData();
  System.out.println("Result * 2 = " + (myLong * 2));
}
```