### PR TITLE
refactor: mapping

### DIFF
--- a/src/main/java/io/github/janmalch/kino/api/model/SignUpDto.java
+++ b/src/main/java/io/github/janmalch/kino/api/model/SignUpDto.java
@@ -1,12 +1,17 @@
 package io.github.janmalch.kino.api.model;
 
+import java.time.LocalDate;
+import javax.json.bind.annotation.JsonbDateFormat;
+
 public class SignUpDto {
 
   private String firstName;
   private String lastName;
   private String password;
   private String email;
-  private String birthday;
+
+  @JsonbDateFormat(value = "yyyy-MM-dd", locale = "de-DE")
+  private LocalDate birthday;
 
   public String getFirstName() {
     return firstName;
@@ -40,11 +45,11 @@ public class SignUpDto {
     this.email = email;
   }
 
-  public String getBirthday() {
+  public LocalDate getBirthday() {
     return birthday;
   }
 
-  public void setBirthday(String birthday) {
+  public void setBirthday(LocalDate birthday) {
     this.birthday = birthday;
   }
 

--- a/src/main/java/io/github/janmalch/kino/control/validation/BeanValidations.java
+++ b/src/main/java/io/github/janmalch/kino/control/validation/BeanValidations.java
@@ -1,8 +1,7 @@
 package io.github.janmalch.kino.control.validation;
 
 import io.github.janmalch.kino.problem.Problem;
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
+import io.github.janmalch.kino.util.BeanUtils;
 import java.util.*;
 import java.util.stream.Stream;
 import javax.validation.constraints.NotNull;
@@ -49,30 +48,6 @@ public class BeanValidations<T> {
   }
 
   Stream<Map.Entry<String, Object>> propStream() {
-    return this.beanProperties().entrySet().stream();
-  }
-
-  // https://stackoverflow.com/a/8524043
-  Map<String, Object> beanProperties() {
-    try {
-      Map<String, Object> map = new HashMap<>();
-      Arrays.stream(
-              Introspector.getBeanInfo(data.getClass(), Object.class).getPropertyDescriptors())
-          // filter out properties with setters only
-          .filter(pd -> Objects.nonNull(pd.getReadMethod()))
-          .forEach(
-              pd -> { // invoke method to get value
-                try {
-                  Object value = pd.getReadMethod().invoke(data);
-                  map.put(pd.getName(), value);
-                } catch (Exception e) {
-                  // add proper error handling here
-                }
-              });
-      return map;
-    } catch (IntrospectionException e) {
-      // add proper error handling here
-      return Collections.emptyMap();
-    }
+    return BeanUtils.getBeanProperties(data).entrySet().stream();
   }
 }

--- a/src/main/java/io/github/janmalch/kino/control/validation/SignUpDtoValidator.java
+++ b/src/main/java/io/github/janmalch/kino/control/validation/SignUpDtoValidator.java
@@ -3,43 +3,20 @@ package io.github.janmalch.kino.control.validation;
 import io.github.janmalch.kino.api.model.SignUpDto;
 import io.github.janmalch.kino.problem.Problem;
 import io.github.janmalch.kino.util.Contract;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Optional;
-import javax.ws.rs.core.Response;
 
+/**
+ * @deprecated Use BeanValidations instead
+ * @see BeanValidations#requireNotEmpty(String...)
+ */
+@Deprecated
 public class SignUpDtoValidator implements Validator<SignUpDto> {
-
-  private final SimpleDateFormat birthdayFormat = new SimpleDateFormat("yyyy-MM-dd");
 
   @Override
   public Optional<Problem> validate(SignUpDto data) {
     Contract.require(data != null, "SignUp data is null");
 
     var validator = new BeanValidations<>(data, "sign-up");
-    return validator
-        .requireNotEmpty(/* check all fields for null/empty */ )
-        .or(() -> checkValidBirthday(data));
-  }
-
-  Optional<Problem> checkValidBirthday(SignUpDto data) {
-    try {
-      birthdayFormat.parse(data.getBirthday());
-      return Optional.empty();
-    } catch (ParseException e) {
-      Problem problem =
-          Problem.builder()
-              .type("sign-up/invalid-date-format")
-              .title("Birthday has an invalid format")
-              .status(Response.Status.BAD_REQUEST)
-              .detail(
-                  String.format(
-                      "The given birthday '%s' has an invalid format", data.getBirthday()))
-              .instance()
-              .parameter("birthday", data.getBirthday())
-              .build();
-
-      return Optional.of(problem);
-    }
+    return validator.requireNotEmpty(/* check all fields for null/empty */ );
   }
 }

--- a/src/main/java/io/github/janmalch/kino/entity/Account.java
+++ b/src/main/java/io/github/janmalch/kino/entity/Account.java
@@ -1,6 +1,7 @@
 package io.github.janmalch.kino.entity;
 
-import java.util.Date;
+import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
 import javax.persistence.*;
 import javax.validation.constraints.Email;
@@ -20,7 +21,7 @@ public class Account {
 
   @Email private String email;
 
-  private Date birthday;
+  private LocalDate birthday;
 
   private Role role;
 
@@ -60,11 +61,11 @@ public class Account {
     this.email = email;
   }
 
-  public Date getBirthday() {
+  public LocalDate getBirthday() {
     return birthday;
   }
 
-  public void setBirthday(Date birthday) {
+  public void setBirthday(LocalDate birthday) {
     this.birthday = birthday;
   }
 
@@ -98,5 +99,33 @@ public class Account {
 
   public void setHashedPassword(String hashedPassword) {
     this.hashedPassword = hashedPassword;
+  }
+
+  @Override
+  public String toString() {
+    return "Account{"
+        + "id="
+        + id
+        + ", reservations="
+        + reservations
+        + ", firstName='"
+        + firstName
+        + '\''
+        + ", lastName='"
+        + lastName
+        + '\''
+        + ", email='"
+        + email
+        + '\''
+        + ", birthday="
+        + birthday
+        + ", role="
+        + role
+        + ", salt="
+        + Arrays.toString(salt)
+        + ", hashedPassword='"
+        + hashedPassword
+        + '\''
+        + '}';
   }
 }

--- a/src/main/java/io/github/janmalch/kino/repository/TransactionProvider.java
+++ b/src/main/java/io/github/janmalch/kino/repository/TransactionProvider.java
@@ -1,5 +1,6 @@
 package io.github.janmalch.kino.repository;
 
+import io.github.janmalch.kino.util.functions.VoidConsumer;
 import java.util.function.Supplier;
 import javax.persistence.EntityManager;
 

--- a/src/main/java/io/github/janmalch/kino/util/BeanUtils.java
+++ b/src/main/java/io/github/janmalch/kino/util/BeanUtils.java
@@ -1,0 +1,120 @@
+package io.github.janmalch.kino.util;
+
+import static io.github.janmalch.kino.util.functions.FunctionUtils.uncheck;
+
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class BeanUtils {
+
+  /**
+   * Returns a stream of the properties for the given target class. If the retrieveSetters flag is
+   * set to true, only property descriptors with at least a setter method will be returned. If the
+   * retrieveSetters flag is set to false, only property descriptors with at least a getter method
+   * will be returned.
+   *
+   * @param targetClass the class to retrieve methods from
+   * @param retrieveSetters flag, to determine if setters or getters are wanted
+   * @return Stream of PropertyDescriptor for the targetClass
+   */
+  public static Stream<PropertyDescriptor> streamPropertyDescriptors(
+      Class<?> targetClass, boolean retrieveSetters) {
+    return uncheck(
+        () -> {
+          var stream =
+              Arrays.stream(
+                  Introspector.getBeanInfo(targetClass, Object.class).getPropertyDescriptors());
+          return stream.filter(
+              pd -> Objects.nonNull(retrieveSetters ? pd.getWriteMethod() : pd.getReadMethod()));
+        });
+  }
+
+  /**
+   * Applies all data from the map to the matching setters of the target object.
+   *
+   * @param target the target to be updated
+   * @param data the data for the target
+   */
+  public static void setBeanProperties(Object target, Map<String, Object> data) {
+    streamPropertyDescriptors(target.getClass(), true)
+        .forEach(
+            pd -> {
+              Object value = data.get(pd.getName());
+              if (value == null) {
+                return;
+              }
+
+              uncheck(() -> pd.getWriteMethod().invoke(target, value));
+            });
+  }
+
+  /**
+   * Creates a new instance of the targetClass. All properties from the source will be copied to the
+   * target.
+   *
+   * @param source the source object
+   * @param targetClass the target class
+   * @param <T> the type of the return value
+   * @return an instance of targetClass with data from the source object
+   */
+  public static <T> T clone(Object source, Class<T> targetClass) {
+    return uncheck(
+        () -> {
+          var target = targetClass.getDeclaredConstructor().newInstance();
+          BeanUtils.setBeanProperties(target, BeanUtils.getBeanProperties(source));
+          return target;
+        });
+  }
+
+  /**
+   * Reads all getter methods from the given source object and returns the values in a map.
+   *
+   * @param source the object to read from
+   * @return a map with all getter values
+   * @author https://stackoverflow.com/a/8524043
+   */
+  public static Map<String, Object> getBeanProperties(Object source) {
+    Map<String, Object> map = new HashMap<>();
+    streamPropertyDescriptors(source.getClass(), false)
+        .forEach(
+            pd ->
+                uncheck(
+                    () -> {
+                      Object value = pd.getReadMethod().invoke(source);
+                      map.put(pd.getName(), value);
+                    }));
+    return map;
+  }
+
+  /**
+   * Calls getBeanProperties and then removes all values which are null or it's toString is empty.
+   *
+   * @param source the object to read from
+   * @return a map with all non-empty getter values
+   * @see BeanUtils#getBeanProperties(Object)
+   * @see BeanUtils#isNullOrEmpty(Object)
+   */
+  public static Map<String, Object> getNonEmptyBeanProperties(Object source) {
+    return getBeanProperties(source)
+        .entrySet()
+        .stream()
+        .filter(entry -> !isNullOrEmpty(entry.getValue()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  /**
+   * Returns true, if the given value is null or its string representation is empty
+   *
+   * @param value the value to check
+   * @return if value is null or string representation is empty
+   */
+  public static boolean isNullOrEmpty(Object value) {
+    return value == null || value.toString().trim().isEmpty();
+  }
+}

--- a/src/main/java/io/github/janmalch/kino/util/BeanUtils.java
+++ b/src/main/java/io/github/janmalch/kino/util/BeanUtils.java
@@ -13,6 +13,8 @@ import java.util.stream.Stream;
 
 public class BeanUtils {
 
+  private BeanUtils() {}
+
   /**
    * Returns a stream of the properties for the given target class. If the retrieveSetters flag is
    * set to true, only property descriptors with at least a setter method will be returned. If the

--- a/src/main/java/io/github/janmalch/kino/util/ReflectionMapper.java
+++ b/src/main/java/io/github/janmalch/kino/util/ReflectionMapper.java
@@ -1,17 +1,58 @@
 package io.github.janmalch.kino.util;
 
+import java.util.Collections;
+import java.util.Map;
+
 public class ReflectionMapper {
 
+  /** @see ReflectionMapper#update(Object, Object, Class, Map) */
   public <S, R> R update(S update, R existing, Class<R> targetClass) {
+    return this.update(update, existing, targetClass, Collections.emptyMap());
+  }
+
+  /**
+   * Creates a new instance, based on the data of the existing object. Afterwards all non-empty
+   * properties from the update object will be applied to the new instance. Finally all supplied
+   * values will overwrite those in the new instance.
+   *
+   * @param update the update data, may be partial
+   * @param existing the existing object with the initial values
+   * @param targetClass the class of the target object
+   * @param supplies additional supplied values that will overwrite
+   * @param <S> the source type
+   * @param <R> the resulting type
+   * @return an instance of the same type as the existing
+   * @see BeanUtils#isNullOrEmpty(Object)
+   */
+  public <S, R> R update(S update, R existing, Class<R> targetClass, Map<String, Object> supplies) {
     // clone the existing into the target
     var target = BeanUtils.clone(existing, targetClass);
     // get updated props (not null or empty)
     var updatedProps = BeanUtils.getNonEmptyBeanProperties(update);
     BeanUtils.setBeanProperties(target, updatedProps);
+    BeanUtils.setBeanProperties(target, supplies);
     return target;
   }
 
+  /** @see ReflectionMapper#map(Object, Class, Map) */
   public <S, R> R map(S source, Class<R> targetClass) {
-    return BeanUtils.clone(source, targetClass);
+    return this.map(source, targetClass, Collections.emptyMap());
+  }
+
+  /**
+   * Creates a new instance, based on the data of the existing source object. Finally all supplied
+   * values will overwrite those in the new instance.
+   *
+   * @param source the source object
+   * @param targetClass the class of the target object
+   * @param supplies additional supplied values that will overwrite
+   * @param <S> the source type
+   * @param <R> the resulting type
+   * @return an instance of the given targetClass, with the values from the source object
+   */
+  public <S, R> R map(S source, Class<R> targetClass, Map<String, Object> supplies) {
+    var result = BeanUtils.clone(source, targetClass);
+    BeanUtils.setBeanProperties(result, supplies);
+    return result;
   }
 }

--- a/src/main/java/io/github/janmalch/kino/util/ReflectionMapper.java
+++ b/src/main/java/io/github/janmalch/kino/util/ReflectionMapper.java
@@ -1,0 +1,17 @@
+package io.github.janmalch.kino.util;
+
+public class ReflectionMapper {
+
+  public <S, R> R update(S update, R existing, Class<R> targetClass) {
+    // clone the existing into the target
+    var target = BeanUtils.clone(existing, targetClass);
+    // get updated props (not null or empty)
+    var updatedProps = BeanUtils.getNonEmptyBeanProperties(update);
+    BeanUtils.setBeanProperties(target, updatedProps);
+    return target;
+  }
+
+  public <S, R> R map(S source, Class<R> targetClass) {
+    return BeanUtils.clone(source, targetClass);
+  }
+}

--- a/src/main/java/io/github/janmalch/kino/util/functions/FunctionUtils.java
+++ b/src/main/java/io/github/janmalch/kino/util/functions/FunctionUtils.java
@@ -4,6 +4,8 @@ import java.util.function.Function;
 
 public class FunctionUtils {
 
+  private FunctionUtils() {}
+
   public static <T, R, E extends Exception> Function<T, R> uncheck(
       FunctionWithException<T, R, E> function) {
     return input -> {

--- a/src/main/java/io/github/janmalch/kino/util/functions/FunctionUtils.java
+++ b/src/main/java/io/github/janmalch/kino/util/functions/FunctionUtils.java
@@ -1,0 +1,33 @@
+package io.github.janmalch.kino.util.functions;
+
+import java.util.function.Function;
+
+public class FunctionUtils {
+
+  public static <T, R, E extends Exception> Function<T, R> uncheck(
+      FunctionWithException<T, R, E> function) {
+    return input -> {
+      try {
+        return function.apply(input);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    };
+  }
+
+  public static <R, E extends Exception> R uncheck(SupplierWithException<R, E> supplier) {
+    try {
+      return supplier.get();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static <E extends Exception> void uncheck(VoidConsumerWithException<E> consumer) {
+    try {
+      consumer.execute();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/io/github/janmalch/kino/util/functions/FunctionWithException.java
+++ b/src/main/java/io/github/janmalch/kino/util/functions/FunctionWithException.java
@@ -1,0 +1,5 @@
+package io.github.janmalch.kino.util.functions;
+
+public interface FunctionWithException<T, R, E extends Exception> {
+  R apply(T t) throws E;
+}

--- a/src/main/java/io/github/janmalch/kino/util/functions/SupplierWithException.java
+++ b/src/main/java/io/github/janmalch/kino/util/functions/SupplierWithException.java
@@ -1,0 +1,5 @@
+package io.github.janmalch.kino.util.functions;
+
+public interface SupplierWithException<R, E extends Exception> {
+  R get() throws E;
+}

--- a/src/main/java/io/github/janmalch/kino/util/functions/VoidConsumer.java
+++ b/src/main/java/io/github/janmalch/kino/util/functions/VoidConsumer.java
@@ -1,4 +1,4 @@
-package io.github.janmalch.kino.repository;
+package io.github.janmalch.kino.util.functions;
 
 /** Represents an operation that accepts a no input arguments and returns no result. */
 public interface VoidConsumer {

--- a/src/main/java/io/github/janmalch/kino/util/functions/VoidConsumerWithException.java
+++ b/src/main/java/io/github/janmalch/kino/util/functions/VoidConsumerWithException.java
@@ -1,0 +1,5 @@
+package io.github.janmalch.kino.util.functions;
+
+public interface VoidConsumerWithException<E extends Exception> {
+  void execute() throws E;
+}

--- a/src/test/java/io/github/janmalch/kino/api/boundary/LoginResourceTest.java
+++ b/src/test/java/io/github/janmalch/kino/api/boundary/LoginResourceTest.java
@@ -7,6 +7,7 @@ import io.github.janmalch.kino.api.model.SignUpDto;
 import io.github.janmalch.kino.api.model.TokenDto;
 import io.github.janmalch.kino.security.JwtTokenFactory;
 import io.github.janmalch.kino.success.Success;
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 
 class LoginResourceTest {
@@ -28,7 +29,7 @@ class LoginResourceTest {
     dto.setEmail("test@example.com");
     dto.setFirstName("Test");
     dto.setLastName("Dude");
-    dto.setBirthday("1990-01-01");
+    dto.setBirthday(LocalDate.now());
     dto.setPassword("Start123");
     var signUpResponse = resource.signUp(dto);
     if (signUpResponse.getStatus() != 200) {

--- a/src/test/java/io/github/janmalch/kino/api/boundary/UserResourceTest.java
+++ b/src/test/java/io/github/janmalch/kino/api/boundary/UserResourceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import io.github.janmalch.kino.api.model.SignUpDto;
 import io.github.janmalch.kino.repository.UserRepository;
 import io.github.janmalch.kino.repository.specification.UserByEmailSpec;
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 
 class UserResourceTest {
@@ -16,7 +17,7 @@ class UserResourceTest {
     dto.setEmail("signUp@example.com");
     dto.setFirstName("Test");
     dto.setLastName("Dude");
-    dto.setBirthday("1990-01-01");
+    dto.setBirthday(LocalDate.now());
     dto.setPassword("Start123");
     var response = resource.signUp(dto);
     assertEquals(200, response.getStatus());

--- a/src/test/java/io/github/janmalch/kino/control/LogInControlTest.java
+++ b/src/test/java/io/github/janmalch/kino/control/LogInControlTest.java
@@ -7,6 +7,7 @@ import io.github.janmalch.kino.api.boundary.UserResource;
 import io.github.janmalch.kino.api.model.LoginDto;
 import io.github.janmalch.kino.api.model.SignUpDto;
 import io.github.janmalch.kino.util.either.EitherResultBuilder;
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 
 class LogInControlTest {
@@ -31,7 +32,7 @@ class LogInControlTest {
     dto.setEmail("logIn@example.com");
     dto.setFirstName("Test");
     dto.setLastName("Dude");
-    dto.setBirthday("1990-01-01");
+    dto.setBirthday(LocalDate.now());
     dto.setPassword("Start123");
     var signUpResponse = resource.signUp(dto);
     if (signUpResponse.getStatus() != 200) {

--- a/src/test/java/io/github/janmalch/kino/control/account/SignUpControlTest.java
+++ b/src/test/java/io/github/janmalch/kino/control/account/SignUpControlTest.java
@@ -3,11 +3,11 @@ package io.github.janmalch.kino.control.account;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.janmalch.kino.api.ResponseResultBuilder;
 import io.github.janmalch.kino.api.model.SignUpDto;
 import io.github.janmalch.kino.entity.Account;
 import io.github.janmalch.kino.repository.UserRepository;
-import java.util.HashMap;
+import io.github.janmalch.kino.util.either.EitherResultBuilder;
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 
 class SignUpControlTest {
@@ -19,7 +19,7 @@ class SignUpControlTest {
     data.setFirstName("Test");
     data.setLastName("Account");
     data.setPassword("Start123");
-    data.setBirthday("1990-01-01");
+    data.setBirthday(LocalDate.now());
     var control = new SignUpControl(data);
     var result = control.validateSignUpDto();
     assertTrue(result.isEmpty());
@@ -32,13 +32,13 @@ class SignUpControlTest {
     data.setFirstName("Test");
     // lastName missing
     data.setPassword("Start123");
-    data.setBirthday("1990-01-01");
+    data.setBirthday(LocalDate.now());
     var control = new SignUpControl(data);
-    var response = control.execute(new ResponseResultBuilder<>());
-    assertEquals(400, response.getStatus());
-    var problem = (HashMap<String, Object>) response.getEntity(); // TODO: refactor when new mapper
-    assertEquals("A required field is empty", problem.get("title"));
-    assertEquals("The required field 'lastName' is empty", problem.get("detail"));
+    var response = control.execute(new EitherResultBuilder<>());
+    assertEquals(400, response.getStatus().getStatusCode());
+    var problem = response.getProblem();
+    assertEquals("A required field is empty", problem.getTitle());
+    assertEquals("The required field 'lastName' is empty", problem.getDetail());
   }
 
   @Test
@@ -53,13 +53,13 @@ class SignUpControlTest {
     data.setFirstName("Test");
     data.setLastName("Account");
     data.setPassword("Start123");
-    data.setBirthday("1990-01-01");
+    data.setBirthday(LocalDate.now());
 
     var control = new SignUpControl(data);
-    var response = control.execute(new ResponseResultBuilder<>());
-    assertEquals(400, response.getStatus());
-    var problem = (HashMap<String, Object>) response.getEntity(); // TODO: refactor when new mapper
+    var response = control.execute(new EitherResultBuilder<>());
+    assertEquals(400, response.getStatus().getStatusCode());
+    var problem = response.getProblem();
     assertEquals(
-        "An account with the email 'existing@example.com' already exists", problem.get("detail"));
+        "An account with the email 'existing@example.com' already exists", problem.getDetail());
   }
 }

--- a/src/test/java/io/github/janmalch/kino/control/account/SignUpMapperTest.java
+++ b/src/test/java/io/github/janmalch/kino/control/account/SignUpMapperTest.java
@@ -1,24 +1,24 @@
 package io.github.janmalch.kino.control.account;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import io.github.janmalch.kino.api.model.SignUpDto;
 import io.github.janmalch.kino.security.PasswordManager;
-import java.text.ParseException;
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 
-public class SignUpMapperTest {
+class SignUpMapperTest {
 
   @Test
-  public void mapToEntity() {
+  void mapToEntity() {
+    var bday = LocalDate.now();
     var signUpDto = new SignUpDto();
     var pm = new PasswordManager();
     signUpDto.setEmail("test@example.com");
     signUpDto.setFirstName("Test");
     signUpDto.setLastName("Account");
     signUpDto.setPassword("Start123");
-    signUpDto.setBirthday("1990-01-01");
+    signUpDto.setBirthday(bday);
 
     var mapper = new SignUpControl.SignUpMapper();
     var entity = mapper.mapToEntity(signUpDto);
@@ -27,28 +27,6 @@ public class SignUpMapperTest {
     assertEquals("Test", entity.getFirstName());
     assertEquals("Account", entity.getLastName());
     assertEquals(pm.hashPassword("Start123", entity.getSalt()), entity.getHashedPassword());
-    // TODO: fix SimpleDateFormat in mapper
-    // var formatter = new SimpleDateFormat("yyyy-MM-dd");
-    // assertEquals("1990-01-01", formatter.format(entity.getBirthday()));
-  }
-
-  @Test
-  public void mapToEntityInvalidBirthday() {
-    var signUpDto = new SignUpDto();
-    signUpDto.setEmail("test@example.com");
-    signUpDto.setFirstName("Test");
-    signUpDto.setLastName("Account");
-    signUpDto.setPassword("Start123");
-    signUpDto.setBirthday("19g90-01-01");
-
-    var mapper = new SignUpControl.SignUpMapper();
-    try {
-      mapper.mapToEntity(signUpDto);
-      fail();
-    } catch (RuntimeException e) {
-      if (!(e.getCause() instanceof ParseException)) {
-        fail("Unknown cause of RuntimeException");
-      }
-    }
+    assertEquals(bday, entity.getBirthday());
   }
 }

--- a/src/test/java/io/github/janmalch/kino/control/validation/BeanValidationsTest.java
+++ b/src/test/java/io/github/janmalch/kino/control/validation/BeanValidationsTest.java
@@ -3,6 +3,7 @@ package io.github.janmalch.kino.control.validation;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.github.janmalch.kino.api.model.SignUpDto;
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 
 class BeanValidationsTest {
@@ -14,7 +15,7 @@ class BeanValidationsTest {
     data.setFirstName(""); // firstName is empty, which is not allowed
     data.setLastName("Account");
     data.setPassword("Start123");
-    data.setBirthday("1990-01-01");
+    data.setBirthday(LocalDate.now());
 
     var validator = new BeanValidations<>(data, "test");
     var result = validator.requireNotEmpty(/* everything must be set*/ );

--- a/src/test/java/io/github/janmalch/kino/control/validation/SignUpDtoValidatorTest.java
+++ b/src/test/java/io/github/janmalch/kino/control/validation/SignUpDtoValidatorTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import io.github.janmalch.kino.api.model.SignUpDto;
 import io.github.janmalch.kino.problem.Problem;
+import java.time.LocalDate;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +17,7 @@ class SignUpDtoValidatorTest {
     data.setFirstName("Test");
     data.setLastName("Account");
     data.setPassword("Start123");
-    data.setBirthday("1990-01-01");
+    data.setBirthday(LocalDate.now());
     SignUpDtoValidator validator = new SignUpDtoValidator();
     Optional<Problem> result = validator.validate(data);
     assertTrue(result.isEmpty());
@@ -29,25 +30,11 @@ class SignUpDtoValidatorTest {
     data.setFirstName("Test");
     data.setLastName("Account");
     data.setPassword("Start123");
-    data.setBirthday("1990-01-01");
+    data.setBirthday(LocalDate.now());
     SignUpDtoValidator validator = new SignUpDtoValidator();
     Optional<Problem> result = validator.validate(data);
     assertTrue(result.isPresent());
     assertEquals("The required field 'email' is empty", result.get().getDetail());
-  }
-
-  @Test
-  void validateDateIsInvalid() {
-    SignUpDto data = new SignUpDto();
-    data.setEmail("test@example.com");
-    data.setFirstName("Test");
-    data.setLastName("Account");
-    data.setPassword("Start123");
-    data.setBirthday("1990:01-01");
-    SignUpDtoValidator validator = new SignUpDtoValidator();
-    Optional<Problem> result = validator.validate(data);
-    assertTrue(result.isPresent());
-    assertEquals("The given birthday '1990:01-01' has an invalid format", result.get().getDetail());
   }
 
   @Test

--- a/src/test/java/io/github/janmalch/kino/util/ReflectionMapperTest.java
+++ b/src/test/java/io/github/janmalch/kino/util/ReflectionMapperTest.java
@@ -1,0 +1,43 @@
+package io.github.janmalch.kino.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.github.janmalch.kino.api.model.MovieDto;
+import io.github.janmalch.kino.entity.Movie;
+import org.junit.jupiter.api.Test;
+
+class ReflectionMapperTest {
+
+  @Test
+  void map() {
+    var mapper = new ReflectionMapper();
+    var entity = new Movie();
+    entity.setId(1L);
+    entity.setName("Captain Marvel");
+    entity.setPriceCategory("1");
+    entity.setDuration(2.5F);
+
+    var domain = mapper.map(entity, MovieDto.class);
+    assertEquals("Captain Marvel", domain.getName());
+  }
+
+  @Test
+  void update() {
+    var mapper = new ReflectionMapper();
+
+    var entity = new Movie();
+    entity.setId(1L);
+    entity.setName("Captain Marvel");
+    entity.setPriceCategory("1");
+    entity.setDuration(2.5F);
+
+    var domain = mapper.map(entity, MovieDto.class);
+    domain.setName("Wonder Woman");
+    domain.setPriceCategory("");
+
+    var newEntity = mapper.update(domain, entity, Movie.class);
+    assertEquals(1L, newEntity.getId());
+    assertEquals("Wonder Woman", newEntity.getName());
+    assertEquals("1", newEntity.getPriceCategory(), "Empty values should not be used");
+  }
+}

--- a/src/test/java/io/github/janmalch/kino/util/functions/FunctionUtilsTest.java
+++ b/src/test/java/io/github/janmalch/kino/util/functions/FunctionUtilsTest.java
@@ -1,0 +1,85 @@
+package io.github.janmalch.kino.util.functions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class FunctionUtilsTest {
+
+  private int throwIfZero(int input) throws IllegalArgumentException {
+    if (input == 0) {
+      throw new IllegalArgumentException();
+    }
+    return input;
+  }
+
+  @Test
+  void uncheck() {
+    FunctionWithException<Integer, Integer, IllegalArgumentException> fn = this::throwIfZero;
+
+    try {
+      FunctionUtils.uncheck(fn).apply(0);
+      fail("Should throw RuntimeException");
+    } catch (RuntimeException e) {
+      if (!(e.getCause() instanceof IllegalArgumentException)) {
+        fail("RuntimeException should be caused by IllegalArgumentException");
+      }
+    }
+
+    try {
+      var result = FunctionUtils.uncheck(fn).apply(10);
+      assertEquals(10, result);
+    } catch (RuntimeException e) {
+      fail("Should not throw RuntimeException");
+    }
+  }
+
+  @Test
+  void uncheck1() {
+    SupplierWithException<Integer, IllegalArgumentException> fnEx = () -> this.throwIfZero(0);
+
+    try {
+      FunctionUtils.uncheck(fnEx);
+      fail("Should throw RuntimeException");
+    } catch (RuntimeException e) {
+      if (!(e.getCause() instanceof IllegalArgumentException)) {
+        fail("RuntimeException should be caused by IllegalArgumentException");
+      }
+    }
+
+    SupplierWithException<Integer, IllegalArgumentException> fn = () -> this.throwIfZero(10);
+    try {
+      var result = FunctionUtils.uncheck(fn);
+      assertEquals(10, result);
+    } catch (RuntimeException e) {
+      fail("Should not throw RuntimeException");
+    }
+  }
+
+  @Test
+  void uncheck2() {
+    VoidConsumerWithException<IllegalArgumentException> fnEx =
+        () -> {
+          this.throwIfZero(0);
+        };
+
+    try {
+      FunctionUtils.uncheck(fnEx);
+      fail("Should throw RuntimeException");
+    } catch (RuntimeException e) {
+      if (!(e.getCause() instanceof IllegalArgumentException)) {
+        fail("RuntimeException should be caused by IllegalArgumentException");
+      }
+    }
+
+    VoidConsumerWithException<IllegalArgumentException> fn =
+        () -> {
+          this.throwIfZero(10);
+        };
+    try {
+      FunctionUtils.uncheck(fn);
+    } catch (RuntimeException e) {
+      fail("Should not throw RuntimeException");
+    }
+  }
+}


### PR DESCRIPTION
Refactors how the mapping works to reduce boilerplate code.

:exclamation:  **Changes Account and SignUpDto's birthday field to LocalDate!**

---

### Introduces `ReflectionMapper`

Maps from one class to another based on same property names. You can either `update` existing data or `map` from one type to a completely new instance from another type.

> https://github.com/JanMalch/kino/blob/bddc86a2e0f80912711ee72724bf28c6493d8ede/src/main/java/io/github/janmalch/kino/util/ReflectionMapper.java#L37-L40

##### Usage by example: `map`

```java
public static class SignUpMapper implements Mapper<Account, SignUpDto> {

  private final PasswordManager pm = new PasswordManager();
  private final ReflectionMapper mapper = new ReflectionMapper();

  @Override
  public Account mapToEntity(SignUpDto signUpDto) {
    // copy the present data
    Account account = mapper.map(signUpDto, Account.class);

    // add fields that are missing in SignUpDto
    account.setRole(Role.CUSTOMER);
    var salt = pm.generateSalt();
    var hashedPw = pm.hashPassword(signUpDto.getPassword(), salt);
    account.setSalt(salt);
    account.setHashedPassword(hashedPw);

    return account;
  }
}
```

##### Usage by example: `update`

https://github.com/JanMalch/kino/blob/fa348d88651e0b837b51ae29b7fa9cb7846242bd/src/test/java/io/github/janmalch/kino/util/ReflectionMapperTest.java#L24-L42

---

### Sending day fields in JSON

Use `LocalDate` and `@JsonbDateFormat`

> https://github.com/JanMalch/kino/blob/91ed34b018635fff2c6b23a6fce373235134f1b4/src/main/java/io/github/janmalch/kino/api/model/SignUpDto.java#L13-L14

Closes #9 

#### Note

Timestamps with `"yyyy-MM-dd HH:mm"` have not been tested yet. There is a `LocalDateTime` class. The `java.util.Date` requires the `"yyyy-MM-dd'T'HH:mm:SS"` format.