### PR TITLE
feat: repository factory

### DIFF
--- a/src/main/java/io/github/janmalch/kino/repository/MovieRepository.java
+++ b/src/main/java/io/github/janmalch/kino/repository/MovieRepository.java
@@ -5,6 +5,11 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
+/**
+ * @deprecated Use <code>RepositoryFactory.createRepository(Movie.class);</code> instead
+ * @see RepositoryFactory#createRepository(Class)
+ */
+@Deprecated(forRemoval = true)
 public class MovieRepository implements Repository<Movie> {
 
   private EntityManagerFactory factory = Persistence.createEntityManagerFactory("kino");

--- a/src/main/java/io/github/janmalch/kino/repository/RepositoryFactory.java
+++ b/src/main/java/io/github/janmalch/kino/repository/RepositoryFactory.java
@@ -2,6 +2,8 @@ package io.github.janmalch.kino.repository;
 
 public final class RepositoryFactory {
 
+  private RepositoryFactory() {}
+
   public static <T> Repository<T> createRepository(Class<T> entityType) {
     return new RepositoryImpl<>(entityType);
   }

--- a/src/main/java/io/github/janmalch/kino/repository/RepositoryFactory.java
+++ b/src/main/java/io/github/janmalch/kino/repository/RepositoryFactory.java
@@ -1,0 +1,8 @@
+package io.github.janmalch.kino.repository;
+
+public final class RepositoryFactory {
+
+  public static <T> Repository<T> createRepository(Class<T> entityType) {
+    return new RepositoryImpl<>(entityType);
+  }
+}

--- a/src/main/java/io/github/janmalch/kino/repository/RepositoryImpl.java
+++ b/src/main/java/io/github/janmalch/kino/repository/RepositoryImpl.java
@@ -1,0 +1,26 @@
+package io.github.janmalch.kino.repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+final class RepositoryImpl<T> implements Repository<T> {
+
+  private EntityManagerFactory factory = Persistence.createEntityManagerFactory("kino");
+  private EntityManager em = factory.createEntityManager();
+  private final Class<T> entityType;
+
+  RepositoryImpl(Class<T> entityType) {
+    this.entityType = entityType;
+  }
+
+  @Override
+  public T find(long id) {
+    return em.find(entityType, id);
+  }
+
+  @Override
+  public EntityManager getEntityManager() {
+    return em;
+  }
+}

--- a/src/main/java/io/github/janmalch/kino/repository/UserRepository.java
+++ b/src/main/java/io/github/janmalch/kino/repository/UserRepository.java
@@ -6,6 +6,11 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
 // TODO: currently uses Entity model
+/**
+ * @deprecated Use <code>RepositoryFactory.createRepository(Account.class);</code> instead
+ * @see RepositoryFactory#createRepository(Class)
+ */
+@Deprecated(forRemoval = true)
 public class UserRepository implements Repository<Account> {
 
   private EntityManagerFactory factory = Persistence.createEntityManagerFactory("kino");

--- a/src/test/java/io/github/janmalch/kino/repository/RepositoryFactoryTest.java
+++ b/src/test/java/io/github/janmalch/kino/repository/RepositoryFactoryTest.java
@@ -1,0 +1,22 @@
+package io.github.janmalch.kino.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.janmalch.kino.entity.Account;
+import org.junit.jupiter.api.Test;
+
+class RepositoryFactoryTest {
+
+  @Test
+  void createRepository() {
+    Repository<Account> repository = RepositoryFactory.createRepository(Account.class);
+    var account = new Account();
+    account.setEmail("test@example.com");
+    repository.add(account);
+
+    var id = account.getId();
+
+    var fetched = repository.find(id);
+    assertEquals(account.getEmail(), fetched.getEmail());
+  }
+}


### PR DESCRIPTION
Adds `RepositoryFactory` to further simplify usage of repository pattern and boilerplate code

#### Example

```java
private final Repository<Account> repository = RepositoryFactory.createRepository(Account.class);
```